### PR TITLE
feat(filters): add ternary filter "ifelse"

### DIFF
--- a/provider/data_source_jinja_template.go
+++ b/provider/data_source_jinja_template.go
@@ -127,6 +127,10 @@ func render(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("failed to apply delimiters: %s", err)
 	}
 
+	if err := applyFilters(d, meta); err != nil {
+		return fmt.Errorf("failed to apply filters: %s", err)
+	}
+
 	template, err := parse_template(d)
 	if err != nil {
 		return fmt.Errorf("failed to parse template: %s", err)
@@ -271,5 +275,10 @@ func applyDelimiters(d *schema.ResourceData, meta interface{}) error {
 	gonja.DefaultEnv.Config.CommentStartString = delimiters["comment_start"].(string)
 	gonja.DefaultEnv.Config.CommentEndString = delimiters["comment_end"].(string)
 
+	return nil
+}
+
+func applyFilters(d *schema.ResourceData, meta interface{}) error {
+	gonja.DefaultEnv.Filters.Update(Filters)
 	return nil
 }

--- a/provider/filters.go
+++ b/provider/filters.go
@@ -1,0 +1,36 @@
+package jinja
+
+import (
+	"math/rand"
+	"time"
+
+	"github.com/noirbizarre/gonja/exec"
+	"github.com/pkg/errors"
+)
+
+var Filters = exec.FilterSet{
+	"ifelse": filterIfElse,
+}
+
+func init() {
+	rand.Seed(time.Now().UTC().UnixNano())
+}
+
+func filterIfElse(e *exec.Evaluator, in *exec.Value, params *exec.VarArgs) *exec.Value {
+	p := params.Expect(2, []*exec.KwArg{{Name: "none_val", Default: nil}})
+	if p.IsError() {
+		return exec.AsValue(errors.Wrap(p, "Wrong signature for 'ifelse'"))
+	}
+
+	true_val := p.Args[0].String()
+	false_val := p.Args[1].String()
+	none_val := p.KwArgs["none_val"]
+
+	if in.IsNil() && !none_val.IsNil() {
+		return exec.AsValue(none_val)
+	} else if in.IsTrue() {
+		return exec.AsValue(true_val)
+	} else {
+		return exec.AsValue(false_val)
+	}
+}

--- a/provider/filters_test.go
+++ b/provider/filters_test.go
@@ -1,0 +1,44 @@
+package jinja
+
+import (
+	"fmt"
+	"path"
+	"testing"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestFilterIfElse(t *testing.T) {
+	template, _, dir, remove := mustCreateFile(t.Name(), heredoc.Doc(`
+	true  = {{ "foo" in "foo bar" | ifelse("yes", "no") }}
+	false = {{ "baz" in "foo bar" | ifelse("yes", "no") }}
+
+	`))
+	defer remove()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: heredoc.Doc(`
+				data "jinja_template" "render" {
+					template = "` + path.Join(dir, template) + `"
+				}`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.jinja_template.render", "id"),
+					resource.TestCheckResourceAttrWith("data.jinja_template.render", "result", func(got string) error {
+						expected := heredoc.Doc(`
+						true  = yes
+						false = no
+						`)
+						if expected != got {
+							return fmt.Errorf("\nexpected:\n%s\ngot:\n%s", expected, got)
+						}
+						return nil
+					}),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
Adds a ternary filter callled `ifelse`

```
{{ "foo" in "foo bar" | ifelse("yes", "no") }} => yes
{{ "baz" in "foo bar" | ifelse("yes", "no") }} => no
```

Also supports a third argument, can be used if the base value is `null`.